### PR TITLE
Allow more flexibility in file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,6 @@ var async = require('async');
 var AWS = require('aws-sdk');
 var fs = require('fs');
 
-
-
-
 function S3Zipper(awsConfig) {
     assert.ok(awsConfig, 'AWS S3 options must be defined.');
     assert.notEqual(awsConfig.accessKeyId, undefined, 'Requires S3 AWS Key.');
@@ -15,6 +12,9 @@ function S3Zipper(awsConfig) {
     assert.notEqual(awsConfig.bucket, undefined, 'Requires AWS S3 bucket.');
     this.init(awsConfig);
 }
+
+
+
 S3Zipper.prototype = {
     init: function (awsConfig) {
         this.awsConfig = awsConfig;
@@ -33,10 +33,18 @@ S3Zipper.prototype = {
     ,filterOutFiles: function(fileObj){
         return fileObj;
     }
+    ,calculateFileName: function (f) {
+    var name = f.Key.split("/");
+    name.shift();
+    name = name.join("/");
+    return name;
+
+}
     ,getFiles: function(folderName,startKey,maxFileCount,maxFileSize,callback){
 
         var bucketParams = {
             Bucket: this.awsConfig.bucket, /* required */
+            Marker : 'testtrans01/items',
             Delimiter: "/",
             Prefix: folderName + "/"
         };
@@ -122,9 +130,8 @@ S3Zipper.prototype = {
                         if(err)
                             callback(err);
                         else {
-                            var name = f.Key.split("/");
-                            name.shift();
-                            name = name.join("/");
+
+                            var name = t.calculateFileName(f);
                             console.log('zipping ', name,'...');
 
                             zip.append(data.Body, {name:name});

--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ S3Zipper.prototype = {
 
         var bucketParams = {
             Bucket: this.awsConfig.bucket, /* required */
-            Marker : 'testtrans01/items',
             Delimiter: "/",
             Prefix: folderName + "/"
         };


### PR DESCRIPTION
In current version, code recreate folder structure,
so if you have this folders /a/b/c/d/a.txt

you will get a zip with this structure /b/c/d/a.txt

I add a method to allow developer override this behavior.
You can override "calculateFileName" function to have a flat structure.