### PR TITLE
fix: avoid trying to process non-files

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,12 @@ S3Zipper.prototype = {
                         else {
 
                             var name = t.calculateFileName(f);
+
+                            if (name === ""){
+                                callback(null, f);
+                                return;
+                            }
+
                             console.log('zipping ', name,'...');
 
                             zip.append(data.Body, {name:name});


### PR DESCRIPTION
I have experienced this problem while using the library: sometimes empty names were retrieved from s3 and that caused the library to emit an error.

This fixed the problem in my case - but maybe there are deeper issues. I did not have time to find out.