### PR TITLE
Allow setting S3 endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ Either from the constructor or from the `init(config)` function you can pass alo
     accessKeyId: [Your access id],
     secretAccessKey: [your access key],
     region: [the region of your S3 bucket],
-    bucket: [your bucket name]
+    bucket: [your bucket name],
+    endpoint: [optional, for use with S3-compatible services]
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -41,6 +41,12 @@ S3Zipper.prototype = {
                 });
             }
 
+            if (awsConfig.endpoint) {
+                AWS.config.update({
+                    endpoint: awsConfig.endpoint
+                });
+            }
+
             self.s3bucket = new AWS.S3({
                 params: {
                     Bucket: self.awsConfig.bucket


### PR DESCRIPTION
This PR allows users to optionally set a S3 endpoint. This allows aws-s3-zipper to be used with S3-compatible object storage services like DigitalOcean's Spaces or Minio.