### PR TITLE
Switch to fs.unlinkSync to fix node 10 err

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,12 +306,12 @@ S3Zipper.prototype = {
                         zipFileLocation: result.Location,
                         zippedFiles: r.zippedFiles
                     });
-                    fs.unlink(params.zipFileName);
+                    fs.unlinkSync(params.zipFileName);
                 });
             }
             else {
                 console.log('no files zipped. nothing to upload');
-                fs.unlink(params.zipFileName);
+                fs.unlinkSync(params.zipFileName);
                 callback(null, {
                     zipFileETag: null,
                     zipFileLocation: null,
@@ -382,7 +382,7 @@ S3Zipper.prototype = {
                 if (uploadResult) {
                     result.uploadedFile = uploadResult;
                     console.log('remove temp file ', localFragName);
-                    fs.unlink(localFragName);
+                    fs.unlinkSync(localFragName);
                 }
                 pendingUploads--;
                 if (pendingUploads == 0 && finalResult) {
@@ -483,7 +483,7 @@ S3Zipper.prototype = {
                 fileStream.close();
                 if (result.zippedFiles.length == 0) /// its an empty zip file get rid of it
 
-                    fs.unlink(fragFileName);
+                    fs.unlinkSync(fragFileName);
 
                 else
                     events.onFileZipped(fragFileName, result);


### PR DESCRIPTION
fs.unlink fails without the `callback` param in node 10 it seems. Switching to fs.unlinkSync fixes the problem for me.

```
TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at makeCallback (fs.js:135:11)
    at Object.unlink (fs.js:903:14)
```