### PR TITLE
Adds V4 support so now works on all AWS regions 

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,18 +7,19 @@ var s3 = require('s3');
 
 function S3Zipper(awsConfig) {
     var self = this
-    AWS.config.getCredentials(function (err) {
-      if (err) {
-        assert.ok(awsConfig, 'AWS S3 options must be defined.');
-        assert.notEqual(awsConfig.accessKeyId, undefined, 'Requires S3 AWS Key.');
-        assert.notEqual(awsConfig.secretAccessKey, undefined, 'Requires S3 AWS Secret');
-        assert.notEqual(awsConfig.region, undefined, 'Requires AWS S3 region.');
-        assert.notEqual(awsConfig.bucket, undefined, 'Requires AWS S3 bucket.');
-        self.init(awsConfig);
-      } else {
-        self.init(awsConfig)
-      }
-    })
+    assert.ok(awsConfig, 'AWS S3 options must be defined.');
+    assert.notEqual(awsConfig.accessKeyId, undefined, 'Requires S3 AWS Key.');
+    assert.notEqual(awsConfig.secretAccessKey, undefined, 'Requires S3 AWS Secret');
+    assert.notEqual(awsConfig.region, undefined, 'Requires AWS S3 region.');
+    assert.notEqual(awsConfig.bucket, undefined, 'Requires AWS S3 bucket.');
+
+    AWS.config.update({
+        accessKeyId: awsConfig.accessKeyId,
+        secretAccessKey: awsConfig.secretAccessKey,
+        region: awsConfig.region
+    });
+
+    self.init(awsConfig);
 }
 
 
@@ -31,30 +32,11 @@ S3Zipper.prototype = {
     init: function (awsConfig) {
         this.awsConfig = awsConfig;
         var self = this
-        AWS.config.getCredentials(function (err) {
-
-            if (err) {
-                AWS.config.update({
-                    accessKeyId: awsConfig.accessKeyId,
-                    secretAccessKey: awsConfig.secretAccessKey,
-                    region: awsConfig.region
-                });
+        self.s3bucket = new AWS.S3({
+            params: {
+                Bucket: self.awsConfig.bucket
             }
-
-            if (awsConfig.endpoint) {
-                AWS.config.update({
-                    endpoint: awsConfig.endpoint
-                });
-            }
-
-            self.s3bucket = new AWS.S3({
-                params: {
-                    Bucket: self.awsConfig.bucket
-                }
-            });
-
-        })
-
+        });
     }
     , filterOutFiles: function (fileObj) {
         return fileObj;


### PR DESCRIPTION
Resolves #35 

Error:
`InvalidRequest: The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256.`

Due to the fact that all regions support V4, but US-Standard, and many -- but not all -- other regions, also support the other, older scheme, Signature Version 2 ("V2"). Currently using V2 method. See [stackoverflow](https://stackoverflow.com/questions/26533245/the-authorization-mechanism-you-have-provided-is-not-supported-please-use-aws4) for more details.