### PR TITLE
Optional AWS Credentials and Region

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,17 +8,26 @@ var s3 = require('s3');
 function S3Zipper(awsConfig) {
     var self = this
     assert.ok(awsConfig, 'AWS S3 options must be defined.');
-    assert.notEqual(awsConfig.accessKeyId, undefined, 'Requires S3 AWS Key.');
-    assert.notEqual(awsConfig.secretAccessKey, undefined, 'Requires S3 AWS Secret');
-    assert.notEqual(awsConfig.region, undefined, 'Requires AWS S3 region.');
     assert.notEqual(awsConfig.bucket, undefined, 'Requires AWS S3 bucket.');
 
-    AWS.config.update({
-        accessKeyId: awsConfig.accessKeyId,
-        secretAccessKey: awsConfig.secretAccessKey,
-        region: awsConfig.region
-    });
-
+    /* region is optional in order to use lambda's region */
+    awsConfig.region = awsConfig.region ? awsConfig.region : AWS.config.region;
+    if(!awsConfig.accessKeyId && !awsConfig.secretAccessKey){
+        /*
+        accessKey & secretAccessKey must be optional in order to use grants associated to the lambda function through IAM service
+         */
+        AWS.config.update({
+            region: awsConfig.region
+        });
+    }else{
+        assert.notEqual(awsConfig.accessKeyId, undefined, 'Requires S3 AWS Key.');
+        assert.notEqual(awsConfig.secretAccessKey, undefined, 'Requires S3 AWS Secret');
+        AWS.config.update({
+            accessKeyId: awsConfig.accessKeyId,
+            secretAccessKey: awsConfig.secretAccessKey,
+            region: awsConfig.region
+        });
+    }
     self.init(awsConfig);
 }
 


### PR DESCRIPTION
Credential and region must be optional in order to use grants associated to the lambda through IAM services and to use by default the region to which the function belongs